### PR TITLE
Fix missing links.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,32 +17,32 @@ __Link icons: :book: Official Docs :clapper: Video :page_facing_up: Article :cap
 
 | Topic | Learning Links |
 | ----- | ----- |
-| **Routing and Controllers: Basics** | |
-| Callback Functions and Route::view() |📖 [Basic Routing](https://laravel.com/docs/9.x/routing#basic-routing) <br>📖 [View Routes](https://laravel.com/docs/9.x/routing#view-routes) <br>|
-| Routing to a Single Controller Method |📖 [Basic Controllers with Routes](https://laravel.com/docs/9.x/controllers#basic-controllers) <br>|
-| Route Parameters |📖 [Route Parameters](https://laravel.com/docs/9.x/routing#route-parameters) <br>|
-| Route Naming |📖 [Names Routes](https://laravel.com/docs/9.x/routing#named-routes) <br>|
-| Route Groups |📖 [Route Groups](https://laravel.com/docs/9.x/routing#route-groups) <br>|
-| **Blade Basics** ||
-| Displaying Variables in Blade |📖 [Blade: Displaying Data](https://laravel.com/docs/9.x/blade#displaying-data) <br>|
-| Blade If-Else and Loop Structures |📖 [Blade: If-Statements](https://laravel.com/docs/9.x/blade#if-statements) <br>📖 [Blade Loops](https://laravel.com/docs/9.x/blade#loops) <br>|
-| Layout: @include, @extends, @section, @yield |📖 [Blade: Layout Using Template Inheritance](https://laravel.com/docs/9.x/blade#layouts-using-template-inheritance) <br>|
-| Blade Components |📖 [Blade Components](https://laravel.com/docs/9.x/blade#components) <br>🎬 [Laravel Blade Components: Two Examples - Laravel Breeze/UI](https://www.youtube.com/watch?v=HybWBINeXMw) <br>|
-| **Auth Basics** ||
-| Starter Kits: Breeze (Tailwind) or Laravel UI (Bootstrap) |📖 [Laravel Breeze Official Documentation](https://laravel.com/docs/9.x/starter-kits#laravel-breeze) <br>📖 [Laravel UI: Official Github Page](https://github.com/laravel/ui) <br>|
-| Default Auth Model and Access its Fields from Anywhere |📖 [Retrieving the Authenticated User](https://laravel.com/docs/9.x/authentication#retrieving-the-authenticated-user) <br>|
-| Check Auth in Controller / Blade |📖 [Determining If The Current User Is Authenticated](https://laravel.com/docs/9.x/authentication#determining-if-the-current-user-is-authenticated) <br>📖 [Blade: Authentication Directives](https://laravel.com/docs/9.x/blade#authentication-directives) <br>|
-| Auth Middleware |📖 [Protecting Routes](https://laravel.com/docs/9.x/authentication#protecting-routes) <br>|
+| **Routing and Controllers: Basics** | :question: [Let's Test Your Laravel Routing Skills: Complete 12 Tasks](https://www.youtube.com/watch?v=pENlD3izA3Q) |
+| Callback Functions and Route::view() |:book: [Basic Routing](https://laravel.com/docs/routing#basic-routing) <br>:book: [View Routes](https://laravel.com/docs/routing#view-routes) <br>|
+| Routing to a Single Controller Method |:book: [Basic Controllers with Routes](https://laravel.com/docs/controllers#basic-controllers) <br>|
+| Route Parameters |:book: [Route Parameters](https://laravel.com/docs/routing#route-parameters) <br>|
+| Route Naming |:book: [Names Routes](https://laravel.com/docs/routing#named-routes) <br> :clapper: [Laravel: Why You Need Route Names?](https://www.youtube.com/watch?v=7lalb6HtR1c) <br>|
+| Route Groups |:book: [Route Groups](https://laravel.com/docs/routing#route-groups) <br> :clapper: [Laravel Route Grouping: Simple to Very Complex](https://www.youtube.com/watch?v=I6kyfSmPhn8) <br> :clapper: [More videos](videos/route-groups.md) |
+| **Blade Basics** | :question: [Let's Test Your Laravel Blade Skills: Complete 8 Tasks](https://www.youtube.com/watch?v=P8s7UHuUhbg)<br>:clapper: [9 Quick Tips about Laravel Blade](https://www.youtube.com/watch?v=-Glz1InN68o) <br>|
+| Displaying Variables in Blade |:book: [Blade: Displaying Data](https://laravel.com/docs/blade#displaying-data) <br>|
+| Blade If-Else and Loop Structures |:book: [Blade: If-Statements](https://laravel.com/docs/blade#if-statements) <br>:book: [Blade Loops](https://laravel.com/docs/blade#loops) <br>|
+| Layout: @include, @extends, @section, @yield |:book: [Blade: Layout Using Template Inheritance](https://laravel.com/docs/blade#layouts-using-template-inheritance) <br>|
+| Blade Components |:book: [Blade Components](https://laravel.com/docs/blade#components) <br>:clapper: [Laravel Blade Components: Two Examples - Laravel Breeze/UI](https://www.youtube.com/watch?v=HybWBINeXMw) <br>|
+| **Auth Basics** | :question: [Test Your Laravel Auth Skills: Complete 7 Tasks](https://www.youtube.com/watch?v=v_3NmwtN_S0)<br>:clapper: [8 Tips & Tricks about Laravel Auth](https://www.youtube.com/watch?v=-dpp4CJS6Vk) <br> |
+| Starter Kits: Breeze (Tailwind) or Laravel UI (Bootstrap) |:book: [Laravel Breeze Official Documentation](https://laravel.com/docs/starter-kits#laravel-breeze) <br>:book: [Laravel UI: Official Github Page](https://github.com/laravel/ui) <br> :clapper: [Laravel 8 Auth: 5 "Latest" Things You Need to Know](https://www.youtube.com/watch?v=L1FVdHdEm_8) <br> [More videos](videos/auth-starter-kits.md)<br>|
+| Default Auth Model and Access its Fields from Anywhere |:book: [Retrieving the Authenticated User](https://laravel.com/docs/authentication#retrieving-the-authenticated-user) <br>|
+| Check Auth in Controller / Blade |:book: [Determining If The Current User Is Authenticated](https://laravel.com/docs/authentication#determining-if-the-current-user-is-authenticated) <br>:book: [Blade: Authentication Directives](https://laravel.com/docs/blade#authentication-directives) <br>|
+| Auth Middleware |:book: [Protecting Routes](https://laravel.com/docs/authentication#protecting-routes) <br>|
 | **Database Basics** ||
-| Database Migrations |📖 [Database Migrations](https://laravel.com/docs/9.x/migrations) <br>|
-| Basic Eloquent Model and MVC: Controller -> Model -> View |📖 [Eloquent: Getting Started](https://laravel.com/docs/9.x/eloquent) <br>|
-| Eloquent Relationships: belongsTo / hasMany / belongsToMany |📖 [Eloquent Relationships: One-to-Many](https://laravel.com/docs/9.x/eloquent-relationships#one-to-many) <br>📖 [Eloquent Relationships: BelongsTo](https://laravel.com/docs/9.x/eloquent-relationships#one-to-many-inverse) <br>📖 [Eloquent Relationships: Many-to-Many](https://laravel.com/docs/9.x/eloquent-relationships#many-to-many) <br>|
-| Eager Loading and N+1 Query Problem |📖 [Relationships: Eager Loading](https://laravel.com/docs/9.x/eloquent-relationships#eager-loading) <br>|
+| Database Migrations |:question: [Test Your Laravel Migrations Skills: Complete 10 Tasks](https://www.youtube.com/watch?v=tPU1hNKI_lc)<br>:book: [Database Migrations](https://laravel.com/docs/migrations) <br> :clapper: [Laravel Migrations: Table Created but Foreign Key Failed?](https://www.youtube.com/watch?v=DWzUBpsEEHY) <br> [More videos](videos/database-migrations.md) |
+| Basic Eloquent Model and MVC: Controller -> Model -> View |:question: [Test Your Eloquent Basic Skills: 11 Tasks to Complete](https://www.youtube.com/watch?v=AmvLs9sRSH8)<br>:book: [Eloquent: Getting Started](https://laravel.com/docs/eloquent) <br>|
+| Eloquent Relationships: belongsTo / hasMany / belongsToMany |:question: [Test Your Eloquent Relationships Skills: 9 Tasks to Complete](https://www.youtube.com/watch?v=ohj0Mc09DyE)<br>:book: [Eloquent Relationships: One-to-Many](https://laravel.com/docs/eloquent-relationships#one-to-many) <br>:book: [Eloquent Relationships: BelongsTo](https://laravel.com/docs/eloquent-relationships#one-to-many-inverse) <br>:book: [Eloquent Relationships: Many-to-Many](https://laravel.com/docs/eloquent-relationships#many-to-many) <br> :clapper: [How to Safely Change DB Relations in Live Laravel Project?](https://www.youtube.com/watch?v=nRmoywPJRdM) |
+| Eager Loading and N+1 Query Problem |:book: [Relationships: Eager Loading](https://laravel.com/docs/eloquent-relationships#eager-loading) <br> :clapper: [Laravel N+1 Query Detector: Don't Forget Eager Loading](https://www.youtube.com/watch?v=MbN7BIcUnPA) <br>|
 | **Full Simple CRUD** ||
-| Route Resource and Resourceful Controllers |📖 [Laravel Resource Controllers](https://laravel.com/docs/9.x/controllers#resource-controllers) <br>📄 [Simple Laravel CRUD with Resource Controllers [digitalocean.com]](https://www.digitalocean.com/community/tutorials/simple-laravel-crud-with-resource-controllers) <br>|
-| Forms, Validation and Form Requests |📖 [Laravel Validation](https://laravel.com/docs/9.x/validation) <br>|
-| File Uploads and Storage Folder Basics |📖 [Filesystem: File Uploads](https://laravel.com/docs/9.x/filesystem#file-uploads) <br>|
-| Table Pagination |📖 [Database Pagination](https://laravel.com/docs/9.x/pagination) <br>|
+| Route Resource and Resourceful Controllers |:book: [Laravel Resource Controllers](https://laravel.com/docs/controllers#resource-controllers) <br>:page_facing_up: [Simple Laravel CRUD with Resource Controllers [digitalocean.com]](https://www.digitalocean.com/community/tutorials/simple-laravel-crud-with-resource-controllers) <br> :clapper: [Laravel Nested Resource Controllers: Two-Level Deep](https://www.youtube.com/watch?v=9R_9Xe3Fgnw) <br> :clapper: [More videos](videos/route-resource-resourceful-controllers.md) <br>|
+| Forms, Validation and Form Requests |:question: [Test Your Laravel Validation Skills: Complete 9 Tasks](https://www.youtube.com/watch?v=3ihjumeOMV4)<br>:book: [Laravel Validation](https://laravel.com/docs/validation) <br> :clapper: [New in Laravel 6.13: Format Validation Error Field Name](https://www.youtube.com/watch?v=KD1SqLO58eE) :clapper: [More videos](videos/forms-validation-requests.md) |
+| File Uploads and Storage Folder Basics |:question: [Test Your Laravel File Upload Skills: Complete 7 Tasks](https://www.youtube.com/watch?v=_SrQRnOx3q8)<br>:book: [Filesystem: File Uploads](https://laravel.com/docs/filesystem#file-uploads) <br> :clapper: [Laravel: How to Upload File During User Registration](https://www.youtube.com/watch?v=xyQT2pnv_4E) <br> [More videos](videos/file-uploads-and-storage-folder-basics.md) <br> |
+| Table Pagination |:book: [Database Pagination](https://laravel.com/docs/pagination) <br>|
 
 
 ### Beginner Demo-Project: Personal Blog
@@ -61,47 +61,47 @@ __Link icons: :book: Official Docs :clapper: Video :page_facing_up: Article :cap
 
 | Topic | Learning Links |
 | ----- | ----- |
-| **Routing Advanced** ||
-| Route Model Binding |📖 [Route Model Binding](https://laravel.com/docs/9.x/routing#route-model-binding) <br>🎬 [Laravel Route Model Binding: All You Need To Know](https://www.youtube.com/watch?v=6dEfxGLgevM) <br>|
-| Route Redirect |📖 [Redirect Routes](https://laravel.com/docs/9.x/routing#redirect-routes) <br>|
+| **Routing Advanced** | :clapper: [Laravel: 8 Tips for Advanced Routing](https://www.youtube.com/watch?v=_BIhuX8owTo) <br> :clapper: [More videos](videos/routing-advanced.md) <br> |
+| Route Model Binding |:book: [Route Model Binding](https://laravel.com/docs/routing#route-model-binding) <br>:clapper: [Laravel Route Model Binding: All You Need To Know](https://www.youtube.com/watch?v=6dEfxGLgevM) <br> :clapper: [More videos](videos/route-model-binding.md)|
+| Route Redirect |:book: [Redirect Routes](https://laravel.com/docs/routing#redirect-routes) <br>|
 | **Middleware** ||
-| Create Custom Middleware Class |📖 [Defining Middleware](https://laravel.com/docs/9.x/middleware#defining-middleware) <br>|
+| Create Custom Middleware Class |:book: [Defining Middleware](https://laravel.com/docs/middleware#defining-middleware) <br>|
 | **Database Advanced** ||
-| Database Seeders and Factories |📖 [Database: Seeding](https://laravel.com/docs/9.x/seeding) <br>📖 [Defining Model Factories](https://laravel.com/docs/9.x/database-testing#defining-model-factories) <br>|
-| Eloquent Query Scopes |📖 [Eloquent: Query Scopes](https://laravel.com/docs/9.x/eloquent#query-scopes) <br>|
-| Polymorphic relationships |📖 [Polymorphic Relationships](https://laravel.com/docs/9.x/eloquent-relationships#polymorphic-relationships) <br>|
-| Eloquent Accessors and Mutators |📖 [Accessors & Mutators](https://laravel.com/docs/9.x/eloquent-mutators#accessors-and-mutators) <br>|
-| Eloquent Collections |📖 [Eloquent Collections](https://laravel.com/docs/9.x/eloquent-collections) <br>📖 [General Laravel Collections](https://laravel.com/docs/9.x/collections) <br>|
-| Soft Deletes |📖 [Soft Deleting](https://laravel.com/docs/9.x/eloquent#soft-deleting) <br>|
+| Database Seeders and Factories |:book: [Database: Seeding](https://laravel.com/docs/seeding) <br>:book: [Defining Model Factories](https://laravel.com/docs/database-testing#defining-model-factories) <br> :clapper: [Laravel Factories: Generate and Re-use Fake Records](https://www.youtube.com/watch?v=MHBDUJ51Pqs) <br> :clapper: [More videos](videos/database-seeders-and-factories.md)|
+| Eloquent Query Scopes |:book: [Eloquent: Query Scopes](https://laravel.com/docs/eloquent#query-scopes) <br> :clapper: [Same Eloquent Where Condition? Refactor into Local Scopes](https://www.youtube.com/watch?v=90xGUIuZsHE) <br>|
+| Polymorphic relationships |:book: [Polymorphic Relationships](https://laravel.com/docs/eloquent-relationships#polymorphic-relationships) <br> :clapper: [Laravel.io Portal: Polymorphic Relations Example](https://www.youtube.com/watch?v=EjJaNGW7vAg) <br>|
+| Eloquent Accessors and Mutators |:book: [Accessors & Mutators](https://laravel.com/docs/eloquent-mutators#accessors-and-mutators) <br>|
+| Eloquent Collections |:book: [Eloquent Collections](https://laravel.com/docs/eloquent-collections) <br>:book: [General Laravel Collections](https://laravel.com/docs/collections) <br>|
+| Soft Deletes |:book: [Soft Deleting](https://laravel.com/docs/eloquent#soft-deleting) <br>|
 | **Auth Advanced** ||
-| Authorization: Roles/Permissions, Gates, Policies |📖 [Authorization](https://laravel.com/docs/9.x/authorization) <br>🎬 [Laravel Roles and Permissions: All CORE Things You Need To Know](https://www.youtube.com/watch?v=kZOgH3-0Bko) <br>|
-| Authorization: Extra Packages - Spatie Permission, Bouncer, etc |🎬 [Spatie Laravel Permission: Example Project Review](https://www.youtube.com/watch?v=NgToi0uiMNQ) <br>📄 [Two Best Laravel Packages to Manage Roles/Permissions](https://laravel-news.com/two-best-roles-permissions-packages) <br>📖 [spatie/laravel-permission](https://github.com/spatie/laravel-permission) <br>📖 [JosephSilber/bouncer](https://github.com/JosephSilber/bouncer) <br>|
-| Authentication: Email Verification |📖 [Email Verification](https://laravel.com/docs/9.x/verification) <br>|
-| **File Uploads Advanced** ||
-| Drivers and Disks, Example of Amazon S3 |📖 [File Storage](https://laravel.com/docs/9.x/filesystem) <br>🎬 [Laravel: How to Upload Files to Amazon S3](https://www.youtube.com/watch?v=xZQM9q_QxMA) <br>|
-| Extra Packages: Spatie Medialibrary, Intervention Image, etc |📖 [spatie/laravel-medialibrary](https://github.com/spatie/laravel-medialibrary) <br>📖 [intervention/image](https://github.com/Intervention/image) <br>|
-| **API Basics** ||
-| API Routes and Controllers |📖 [API Resource Routes](https://laravel.com/docs/9.x/controllers#api-resource-routes) <br>📖 [Default Route Files](https://laravel.com/docs/9.x/routing#the-default-route-files) <br>|
-| Working with API Clients: Postman or Alternatives |📖 [Postman API Client](https://www.postman.com/product/api-client/) <br>|
-| API Eloquent Resources |📖 [Eloquent: API Resources](https://laravel.com/docs/9.x/eloquent-resources) <br>|
-| API Auth with Sanctum |📖 [Laravel Sanctum](https://laravel.com/docs/9.x/sanctum) <br>|
-| API Error Handling and Status Codes |🎬 [Laravel API 404 Error: Customize Exception Message](https://www.youtube.com/watch?v=SlBJrLnyoMk) <br>📄 [HTTP Status Codes](https://httpstatuses.com/) <br>|
+| Authorization: Roles/Permissions, Gates, Policies |:book: [Authorization](https://laravel.com/docs/authorization) <br>:clapper: [Laravel Roles and Permissions: All CORE Things You Need To Know](https://www.youtube.com/watch?v=kZOgH3-0Bko) <br> [More videos](videos/authorization-roles-permissions-gates-policies.md)|
+| Authorization: Extra Packages - Spatie Permission, Bouncer, etc |:clapper: [Spatie Laravel Permission: Example Project Review](https://www.youtube.com/watch?v=NgToi0uiMNQ) <br>:page_facing_up: [Two Best Laravel Packages to Manage Roles/Permissions](https://laravel-news.com/two-best-roles-permissions-packages) <br>:book: [spatie/laravel-permission](https://github.com/spatie/laravel-permission) <br>:book: [JosephSilber/bouncer](https://github.com/JosephSilber/bouncer) <br>|
+| Authentication: Email Verification |:book: [Email Verification](https://laravel.com/docs/verification) <br> :clapper: [How to Translate/Customize Laravel Auth Default Emails](https://www.youtube.com/watch?v=c01k5Zo_CuI) |
+| **File Uploads Advanced** |:capital_abcd: [File Uploads in Laravel](https://laraveldaily.teachable.com/p/file-uploads-in-laravel) <br>|
+| Drivers and Disks, Example of Amazon S3 |:book: [File Storage](https://laravel.com/docs/filesystem) <br>:clapper: [Laravel: How to Upload Files to Amazon S3](https://www.youtube.com/watch?v=xZQM9q_QxMA) <br>|
+| Extra Packages: Spatie Medialibrary, Intervention Image, etc |:book: [spatie/laravel-medialibrary](https://github.com/spatie/laravel-medialibrary) <br>:book: [intervention/image](https://github.com/Intervention/image) <br> :clapper: [Spatie Media Library Pro: Laravel File Uploads with Great UX [REVIEW]](https://www.youtube.com/watch?v=oqW6vlJgXYE) <br> :clapper: [More videos](videos/file-upload-extra-packages.md) <br>|
+| **API Basics** |:capital_abcd: [How to Create Laravel API](https://laraveldaily.teachable.com/p/how-to-create-laravel-api) <br> :clapper: [Create Model with API Controller - in one Artisan Command](https://www.youtube.com/watch?v=DZw2wKzfRVU) <br> [Laravel API: Be Careful When Doing Changes](https://www.youtube.com/watch?v=yXnIW4DkuHQ) <br>|
+| API Routes and Controllers |:book: [API Resource Routes](https://laravel.com/docs/controllers#api-resource-routes) <br>:book: [Default Route Files](https://laravel.com/docs/routing#the-default-route-files) <br> :clapper: [Junior Code Review: Simple Laravel API - in 5 Different Ways](https://www.youtube.com/watch?v=MxQJlFUYO30) <br>|
+| Working with API Clients: Postman or Alternatives |:book: [Postman API Client](https://www.postman.com/product/api-client/) <br>|
+| API Eloquent Resources |:book: [Eloquent: API Resources](https://laravel.com/docs/eloquent-resources) <br> :clapper: [Laravel API Result: Add Fields with Map or Appends](https://www.youtube.com/watch?v=FNU3gYgiEgQ) <br>|
+| API Auth with Sanctum |:book: [Laravel Sanctum](https://laravel.com/docs/sanctum) <br> :clapper: [Laravel API Auth with Sanctum and API Tokens](https://www.youtube.com/watch?v=gyWLxpYWxFQ)<br> :clapper: [More videos](videos/api-auth-with-sanctum.md)<br>|
+| API Error Handling and Status Codes |:clapper: [Laravel API 404 Error: Customize Exception Message](https://www.youtube.com/watch?v=SlBJrLnyoMk) <br>:page_facing_up: [HTTP Status Codes](https://httpstatuses.com/) <br>|
 | **Debugging Errors** ||
-| Log Files in Laravel |📖 [Logging](https://laravel.com/docs/9.x/logging) <br>|
-| Try-Catch and Laravel Exceptions |📖 [Error Handling](https://laravel.com/docs/9.x/errors) <br>🎬 [Exceptions in Laravel: Why/How to Use and Create Your Own](https://www.youtube.com/watch?v=RTTXZVIL6tw) <br>|
-| Local Debugging Tools: Debugbar, Telescope, Ray |📖 [barryvdh/laravel-debugbar](https://github.com/barryvdh/laravel-debugbar) <br>📖 [Laravel Telescope](https://laravel.com/docs/9.x/telescope) <br>📖 [Spatie Ray (Premium Tool)](https://myray.app/) <br>🎬 [Debug Eloquent Queries from API: Laravel Telescope](https://www.youtube.com/watch?v=SR3RzIfeozI) <br>🎬 [Spatie Ray: Laravel Debugging with Pleasure](https://www.youtube.com/watch?v=n4pMxyAXeqY) <br>|
-| Customizing Error Pages and Messages |📖 [Custom HTTP Error Pages](https://laravel.com/docs/9.x/errors#custom-http-error-pages) <br>🎬 [Laravel Error Pages: Change Text or Customize Layouts](https://www.youtube.com/watch?v=iMAFUi6Z57k) <br>|
-| (optional) Third Party Bug Trackers: Bugsnag, Flare, Sentry, Rollbar |📖 [Bugsnag Laravel](https://docs.bugsnag.com/platforms/php/laravel/) <br>📖 [Flare Homepage](https://flareapp.io/) <br>📖 [Sentry Laravel](https://docs.sentry.io/platforms/php/guides/laravel/) <br>📖 [Rollbar Laravel](https://docs.rollbar.com/docs/laravel) <br>🎬 [Bug Tracking in Laravel: Bugsnag vs Flare [Demo/Review]](https://www.youtube.com/watch?v=88UqUXhWwGA) <br>|
-| **Sending Email** ||
-| Mailables and Mail Facade |📖 [Mail & Mailables](https://laravel.com/docs/9.x/mail) <br>|
-| Configure Drivers/Services: Mailgun, Mailtrap, etc |📰 [How to Send Email From Laravel, and Why We Need 3rd Party Providers For It](https://laraveldaily.com/how-to-send-email-from-laravel-and-why-we-need-3rd-party-providers-for-it/) <br>📖 [Mail: Drivers Prerequisites](https://laravel.com/docs/9.x/mail#driver-prerequisites) <br>|
-| Notifications System: Email, SMS, Slack, etc. |📖 [Notifications](https://laravel.com/docs/9.x/notifications) <br>|
-| **Automated Testing with PHPUnit** ||
-| "Smoke" Tests to Check if Pages are Loading |📖 [Testing: Getting Started](https://laravel.com/docs/9.x/testing) <br>[:capital_abcd: Laravel: PHPUnit Testing for Beginners](https://laraveldaily.teachable.com/p/laravel-phpunit-testing-for-beginners) <br>|
-| Configure Testing Database and Test CRUD Operations |📖 [Database Testing](https://laravel.com/docs/9.x/database-testing) <br>|
+| Log Files in Laravel |:book: [Logging](https://laravel.com/docs/logging) <br>|
+| Try-Catch and Laravel Exceptions |:book: [Error Handling](https://laravel.com/docs/errors) <br>:clapper: [Exceptions in Laravel: Why/How to Use and Create Your Own](https://www.youtube.com/watch?v=RTTXZVIL6tw) <br>|
+| Local Debugging Tools: Debugbar, Telescope, Ray |:book: [barryvdh/laravel-debugbar](https://github.com/barryvdh/laravel-debugbar) <br>:book: [Laravel Telescope](https://laravel.com/docs/telescope) <br>:book: [Spatie Ray (Premium Tool)](https://myray.app/) <br>:clapper: [Debug Eloquent Queries from API: Laravel Telescope](https://www.youtube.com/watch?v=SR3RzIfeozI) <br>:clapper: [Spatie Ray: Laravel Debugging with Pleasure](https://www.youtube.com/watch?v=n4pMxyAXeqY) <br>|
+| Customizing Error Pages and Messages |:book: [Custom HTTP Error Pages](https://laravel.com/docs/errors#custom-http-error-pages) <br>:clapper: [Laravel Error Pages: Change Text or Customize Layouts](https://www.youtube.com/watch?v=iMAFUi6Z57k) <br> :clapper: [New in Laravel 8.26: Override 404 Page with Route Missing](https://www.youtube.com/watch?v=nvDCQDkcjN0) <br>|
+| (optional) Third Party Bug Trackers: Bugsnag, Flare, Sentry, Rollbar |:book: [Bugsnag Laravel](https://docs.bugsnag.com/platforms/php/laravel/) <br>:book: [Flare Homepage](https://flareapp.io/) <br>:book: [Sentry Laravel](https://docs.sentry.io/platforms/php/guides/laravel/) <br>:book: [Rollbar Laravel](https://docs.rollbar.com/docs/laravel) <br>:clapper: [Bug Tracking in Laravel: Bugsnag vs Flare [Demo/Review]](https://www.youtube.com/watch?v=88UqUXhWwGA) <br>|
+| **Sending Email** | :clapper: [Laravel: 3 Ways to Send a Welcome Email (Controller vs Observer vs Events)](https://www.youtube.com/watch?v=ZWzH6SOzjhI) |
+| Mailables and Mail Facade |:book: [Mail & Mailables](https://laravel.com/docs/mail) <br>|
+| Configure Drivers/Services: Mailgun, Mailtrap, etc |:page_facing_up: [How to Send Email From Laravel, and Why We Need 3rd Party Providers For It](https://laraveldaily.com/how-to-send-email-from-laravel-and-why-we-need-3rd-party-providers-for-it/) <br>:book: [Mail: Drivers Prerequisites](https://laravel.com/docs/mail#driver-prerequisites) <br>|
+| Notifications System: Email, SMS, Slack, etc. |:book: [Notifications](https://laravel.com/docs/notifications) <br> :clapper: [Laravel Notifications: "Database" Driver - Demo Project](https://www.youtube.com/watch?v=5DREuAvFnps)|
+| **Automated Testing with PHPUnit** | :clapper: [Why People (Don't) Write Automated Tests?](https://www.youtube.com/watch?v=aKgUkYVvqFE) <br>|
+| "Smoke" Tests to Check if Pages are Loading |:book: [Testing: Getting Started](https://laravel.com/docs/testing) <br>:capital_abcd: [Laravel: PHPUnit Testing for Beginners](https://laraveldaily.teachable.com/p/laravel-phpunit-testing-for-beginners) <br> :clapper: [PHPUnit in Laravel: Simple Example of Why/How to Test](https://www.youtube.com/watch?v=DRhhfy2sG1E) <br> |
+| Configure Testing Database and Test CRUD Operations |:book: [Database Testing](https://laravel.com/docs/database-testing) <br>|
 | **Deployment and Version Control** ||
-| Git Version Control |📖 [Git](https://git-scm.com/) <br>🎬 [Git in Laravel. Part 1 - Branches: Main, Develop and Feature](https://www.youtube.com/watch?v=AmScEC-_72I) <br>|
-| Deployment on Live Servers |📖 [Deployment](https://laravel.com/docs/9.x/deployment) <br>📄 [How to Deploy Laravel Projects to Live Server: The Ultimate Guide](https://laraveldaily.com/how-to-deploy-laravel-projects-to-live-server-the-ultimate-guide/) <br>📄 [What Server is Needed to Deploy Laravel Projects](https://laraveldaily.com/what-server-is-needed-to-deploy-laravel-projects/) <br>🎬 [How we Deploy Laravel: Branches, Staging Servers, Forge and Envoyer](https://www.youtube.com/watch?v=8DVuVftFZcQ) <br>|
+| Git Version Control |:book: [Git](https://git-scm.com/) <br>:clapper: [Git in Laravel. Part 1 - Branches: Main, Develop and Feature](https://www.youtube.com/watch?v=AmScEC-_72I) <br> :clapper: [More videos](videos/git-version-control.md)|
+| Deployment on Live Servers |:book: [Deployment](https://laravel.com/docs/deployment) <br>:page_facing_up: [How to Deploy Laravel Projects to Live Server: The Ultimate Guide](https://laraveldaily.com/how-to-deploy-laravel-projects-to-live-server-the-ultimate-guide/) <br>:page_facing_up: [What Server is Needed to Deploy Laravel Projects](https://laraveldaily.com/what-server-is-needed-to-deploy-laravel-projects/) <br>:clapper: [How we Deploy Laravel: Branches, Staging Servers, Forge and Envoyer](https://www.youtube.com/watch?v=8DVuVftFZcQ) <br>|
 
 
 ### Advanced Beginner Demo-Project: Simple CRM
@@ -120,50 +120,51 @@ __Link icons: :book: Official Docs :clapper: Video :page_facing_up: Article :cap
 | Topic | Learning Links |
 | ----- | ----- |
 | **Routing Extra Features** ||
-| Route Caching |📖 [Route Caching](https://laravel.com/docs/9.x/routing#route-caching) <br>|
-| Rate Limiting |📖 [Rate Limiting](https://laravel.com/docs/9.x/routing#rate-limiting) <br>🎬 [Laravel: Create Public API with Cache and Rate Limits](https://www.youtube.com/watch?v=vrLcCxWlxOk) <br>|
-| Invokable controllers |📖 [Single Action Controllers](https://laravel.com/docs/9.x/controllers#single-action-controllers) <br>|
+| Route Caching |:book: [Route Caching](https://laravel.com/docs/routing#route-caching) <br>|
+| Rate Limiting |:book: [Rate Limiting](https://laravel.com/docs/routing#rate-limiting) <br>:clapper: [Laravel: Create Public API with Cache and Rate Limits](https://www.youtube.com/watch?v=vrLcCxWlxOk) <br>|
+| Invokable controllers |:book: [Single Action Controllers](https://laravel.com/docs/controllers#single-action-controllers) <br>|
 | **Database/Eloquent Extra Features** ||
-| Model Observers |📖 [Eloquent Observers](https://laravel.com/docs/9.x/eloquent#observers) <br>🎬 [Laravel Model: Check if Any Field Was Changed](https://www.youtube.com/watch?v=_xluet13xxE) <br>🎬 [Eloquent Observers or Events Listeners? Which is Better?](https://www.youtube.com/watch?v=DvoaU6cQQHM) <br>|
-| Raw Database Queries |📖 [Query Builder: Raw Expressions](https://laravel.com/docs/9.x/queries#raw-expressions) <br>|
-| All Eloquent Features |📖 [All About Eloquent](https://laravel.com/docs/9.x/eloquent) <br>[:capital_abcd: Eloquent: Expert Level](https://laraveldaily.teachable.com/p/laravel-eloquent-expert-level) <br>📄 [20 Laravel Eloquent Tips and Tricks](https://laravel-news.com/eloquent-tips-tricks) <br>|
+| Model Observers |:book: [Eloquent Observers](https://laravel.com/docs/eloquent#observers) <br>:clapper: [Laravel Model: Check if Any Field Was Changed](https://www.youtube.com/watch?v=_xluet13xxE) <br>:clapper: [Eloquent Observers or Events Listeners? Which is Better?](https://www.youtube.com/watch?v=DvoaU6cQQHM) <br>|
+| Raw Database Queries |:book: [Query Builder: Raw Expressions](https://laravel.com/docs/queries#raw-expressions) <br>|
+| All Eloquent Features |:book: [All About Eloquent](https://laravel.com/docs/eloquent) <br>:capital_abcd: [Eloquent: Expert Level](https://laraveldaily.teachable.com/p/laravel-eloquent-expert-level) <br>:page_facing_up: [20 Laravel Eloquent Tips and Tricks](https://laravel-news.com/eloquent-tips-tricks) <br> :clapper: [Laravel Collections: 5 Methods with Real Examples](https://www.youtube.com/watch?v=isAz2GduuA0) <br> [More videos](videos/all-eloquent-features.md) <br>|
 | **Various Extra Laravel Features** ||
-| Caching |📖 [Cache](https://laravel.com/docs/9.x/cache) <br>🎬 [Cache Eloquent Query Results to Load Pages Instantly](https://www.youtube.com/watch?v=JhKngeE0XJA) <br>|
-| Creating Artisan Commands |📖 [Writing Artisan Commands](https://laravel.com/docs/9.x/artisan#writing-commands) <br>🎬 [How to Create Artisan Commands in Laravel](https://www.youtube.com/watch?v=-r3WnYy7g48) <br>|
-| Task Scheduling |📖 [Task Scheduling](https://laravel.com/docs/9.x/scheduling) <br>|
-| Login with X: Laravel Socialite |📖 [Laravel Socialite](https://laravel.com/docs/9.x/socialite) <br>|
-| Laravel HTTP Client and Guzzle |📖 [HTTP Client](https://laravel.com/docs/9.x/http-client) <br>🎬 [Laravel and External APIs: Get Data with HTTP Client](https://www.youtube.com/watch?v=oEDDZsmMLc0) <br>|
-| Custom Blade Directives |📖 [Extending Blade](https://laravel.com/docs/9.x/blade#extending-blade) <br>|
-| Events and Listeners |📖 [Events and Listeners](https://laravel.com/docs/9.x/events) <br>🎬 [Laravel: 3 Ways to Send a Welcome Email (Controller vs Observer vs Events)](https://www.youtube.com/watch?v=ZWzH6SOzjhI) <br>🎬 [Laravel: Why Observers and Event Listeners are "Risky"](https://www.youtube.com/watch?v=A3bmLo77e5M) <br>|
-| **Jobs and Queues** |[:capital_abcd: Queues in Laravel](https://laraveldaily.teachable.com/p/queues-in-laravel) <br>|
-| Queueable Classes and Jobs |📖 [Creating Jobs](https://laravel.com/docs/9.x/queues#creating-jobs) <br>📖 [Queueing Notifications](https://laravel.com/docs/9.x/notifications#queueing-notifications) <br>📖 [Queued Event Listeners](https://laravel.com/docs/9.x/events#queued-event-listeners) <br>📖 [Queueing Mail](https://laravel.com/docs/9.x/mail#queueing-mail) <br>🎬 [Laravel Queues 101: Example with Sending Emails](https://www.youtube.com/watch?v=rVx8xKisbr8) <br>|
-| Processing Failed Jobs |📖 [Dealing with Failed Jobs](https://laravel.com/docs/9.x/queues#dealing-with-failed-jobs) <br>|
-| Job Dispatching, Batching and Chaining |📖 [Dispatching Jobs](https://laravel.com/docs/9.x/queues#dispatching-jobs) <br>|
-| Configuring Queues: Drivers, Redis, Supervisor |📖 [Running the Queue Worker](https://laravel.com/docs/9.x/queues#running-the-queue-worker) <br>📖 [Configuring Supervisor](https://laravel.com/docs/9.x/queues#supervisor-configuration) <br>|
-| Laravel Horizon (optional, if you use Redis) |📖 [Laravel Horizon](https://laravel.com/docs/9.x/horizon) <br>|
+| Custom Blade Directives |:book: [Extending Blade](https://laravel.com/docs/blade#extending-blade) <br>|
+| Events and Listeners |:book: [Events and Listeners](https://laravel.com/docs/events) <br>:clapper: [Laravel: 3 Ways to Send a Welcome Email (Controller vs Observer vs Events)](https://www.youtube.com/watch?v=ZWzH6SOzjhI) <br>:clapper: [Laravel: Why Observers and Event Listeners are "Risky"](https://www.youtube.com/watch?v=A3bmLo77e5M) <br>|
+| Laravel HTTP Client and Guzzle |:book: [HTTP Client](https://laravel.com/docs/http-client) <br>:clapper: [Laravel and External APIs: Get Data with HTTP Client](https://www.youtube.com/watch?v=oEDDZsmMLc0) <br>|
+| Login with X: Laravel Socialite |:book: [Laravel Socialite](https://laravel.com/docs/socialite) <br>|
+| Creating Artisan Commands |:book: [Writing Artisan Commands](https://laravel.com/docs/artisan#writing-commands) <br>:clapper: [How to Create Artisan Commands in Laravel](https://www.youtube.com/watch?v=-r3WnYy7g48) <br>|
+| Task Scheduling |:book: [Task Scheduling](https://laravel.com/docs/scheduling) <br>:clapper: [Laravel Task Scheduling: Run Artisan Command Hourly](https://www.youtube.com/watch?v=r-KrsQ0dN80) <br>|
+| Caching |:book: [Cache](https://laravel.com/docs/cache) <br>:clapper: [Cache Eloquent Query Results to Load Pages Instantly](https://www.youtube.com/watch?v=JhKngeE0XJA) <br>|
+| Real-time: Broadcasting, Echo and Pusher |:book: [Broadcasting](https://laravel.com/docs/broadcasting) <br>|
+| **Jobs and Queues** |:capital_abcd: [Queues in Laravel](https://laraveldaily.teachable.com/p/queues-in-laravel) <br>|
+| Queueable Classes and Jobs |:book: [Creating Jobs](https://laravel.com/docs/queues#creating-jobs) <br>:book: [Queueing Notifications](https://laravel.com/docs/notifications#queueing-notifications) <br>:book: [Queued Event Listeners](https://laravel.com/docs/events#queued-event-listeners) <br>:book: [Queueing Mail](https://laravel.com/docs/mail#queueing-mail) <br>:clapper: [Laravel Queues 101: Example with Sending Emails](https://www.youtube.com/watch?v=rVx8xKisbr8) <br>|
+| Job Dispatching, Batching and Chaining |:book: [Dispatching Jobs](https://laravel.com/docs/queues#dispatching-jobs) <br>|
+| Processing Failed Jobs |:book: [Dealing with Failed Jobs](https://laravel.com/docs/queues#dealing-with-failed-jobs) <br>|
+| Configuring Queues: Drivers, Redis, Supervisor |:book: [Running the Queue Worker](https://laravel.com/docs/queues#running-the-queue-worker) <br>:book: [Configuring Supervisor](https://laravel.com/docs/queues#supervisor-configuration) <br>|
+| Laravel Horizon (optional, if you use Redis) |:book: [Laravel Horizon](https://laravel.com/docs/horizon) <br>|
 | **API Advanced** ||
 | Upload Files via API |:page_facing_up: [Laravel API: How to Upload File from Vue.js](https://blog.quickadminpanel.com/laravel-api-how-to-upload-file-from-vue-js/) <br>|
 | Generate API Documentation |:page_facing_up: [Laravel API Documentation with OpenAPI/Swagger](https://blog.quickadminpanel.com/laravel-api-documentation-with-openapiswagger/) <br>:clapper: [Scribe: New Package for Laravel API Documentation](https://www.youtube.com/watch?v=PjwGI8c2IfA) <br>|
 | API Versioning |:page_facing_up: [Versioning your REST API with Laravel](https://codimth.com/blog/web/laravel/versioning-your-rest-api-laravel) <br>:clapper: [Versioning your API: from V1 to V2 and Beyond [video from my course]](https://laraveldaily.teachable.com/courses/how-to-create-laravel-api/lectures/17568998) <br>|
-| API with OAuth and Laravel Passport |:book: [Laravel Passport](https://laravel.com/docs/8.x/passport) <br> :clapper: [Laravel API Auth Demo: Passport, oAuth and Sanctum](https://www.youtube.com/watch?v=8myQdPL8I1s)|
+| API with OAuth and Laravel Passport |:book: [Laravel Passport](https://laravel.com/docs/passport) <br> :clapper: [Laravel API Auth Demo: Passport, oAuth and Sanctum](https://www.youtube.com/watch?v=8myQdPL8I1s)|
 | Only-API Projects with Front-end like Vue.js |:capital_abcd: [Vue.js + Laravel: CRUD with SPA](https://laraveldaily.teachable.com/p/vue-laravel-crud-spa) <br>|
 | Only-API Projects with Mobile Apps |:page_facing_up: [Using Sanctum to authenticate a mobile app](https://laravel-news.com/using-sanctum-to-authenticate-a-mobile-app) <br>|
 | **(optional) Starter Kits: Laravel Jetstream and Fortify** ||
-| Laravel Jetstream (requires Livewire/Inertia knowledge) |📖 [Laravel Jetstream](https://jetstream.laravel.com) <br>[:capital_abcd: Laravel Jetstream+Livewire: Real Mini-Project](https://laraveldaily.teachable.com/p/laravel-jetstream-livewire-project) <br>🎬 [Laravel Jetstream: How it Works and Example How to Customize](https://www.youtube.com/watch?v=d8YgWApHMfA) <br>|
-| Laravel Fortify |📖 [Laravel Fortify](https://laravel.com/docs/9.x/fortify) <br>🎬 [Laravel Fortify: Four Auth Things to Customize](https://www.youtube.com/watch?v=Vr4LJU3kw1g) <br>|
+| Laravel Jetstream (requires Livewire/Inertia knowledge) |:book: [Laravel Jetstream](https://jetstream.laravel.com) <br>:capital_abcd: [Laravel Jetstream+Livewire: Real Mini-Project](https://laraveldaily.teachable.com/p/laravel-jetstream-livewire-project) <br>:clapper: [Laravel Jetstream: How it Works and Example How to Customize](https://www.youtube.com/watch?v=d8YgWApHMfA) <br>|
+| Laravel Fortify |:book: [Laravel Fortify](https://laravel.com/docs/fortify) <br>:clapper: [Laravel Fortify: Four Auth Things to Customize](https://www.youtube.com/watch?v=Vr4LJU3kw1g) <br>|
 | **Payments** ||
-| Laravel Cashier with Stripe/Paddle |📖 [Laravel Cashier (Stripe)](https://laravel.com/docs/9.x/billing) <br>📖 [Laravel Cashier (Paddle)](https://laravel.com/docs/9.x/cashier-paddle) <br>|
-| Custom Payment Providers: PayPal, Mollie, etc |📄 [Subscription billing with Laravel Cashier for Mollie](https://github.com/laravel/cashier-mollie) <br>📄 [How To Integrate Paypal Payment Gateway In Laravel](https://websolutionstuff.com/post/how-to-integrate-paypal-payment-gateway-in-laravel) <br>|
+| Laravel Cashier with Stripe/Paddle |:book: [Laravel Cashier (Stripe)](https://laravel.com/docs/billing) <br>:book: [Laravel Cashier (Paddle)](https://laravel.com/docs/cashier-paddle) <br>|
+| Custom Payment Providers: PayPal, Mollie, etc |:page_facing_up: [Subscription billing with Laravel Cashier for Mollie](https://github.com/laravel/cashier-mollie) <br>:page_facing_up: [How To Integrate Paypal Payment Gateway In Laravel](https://websolutionstuff.com/post/how-to-integrate-paypal-payment-gateway-in-laravel) <br>|
 | **Automated Testing Advanced** ||
-| TDD: Test-Driven Development |[:capital_abcd: Build A Laravel App With TDD](https://laracasts.com/series/build-a-laravel-app-with-tdd) <br>[:capital_abcd: TDD With Laravel](https://tddwithlaravel.com/) <br>|
-| Mocking |📖 [Mocking](https://laravel.com/docs/9.x/mocking) <br>|
-| (optional) Laravel Dusk |📖 [Laravel Dusk](https://laravel.com/docs/9.x/dusk) <br>|
+| TDD: Test-Driven Development |:capital_abcd: [Build A Laravel App With TDD](https://laracasts.com/series/build-a-laravel-app-with-tdd) <br>:capital_abcd: [TDD With Laravel](https://tddwithlaravel.com/) <br>|
+| Mocking |:book: [Mocking](https://laravel.com/docs/mocking) <br>|
+| (optional) Laravel Dusk |:book: [Laravel Dusk](https://laravel.com/docs/dusk) <br>|
 | **Full-Text Search** ||
-| Laravel Scout |📖 [Laravel Scout](https://laravel.com/docs/9.x/scout) <br>|
-| Drivers: ElasticSearch, Algolia or MeiliSearch |📄 [ElasticSearch Driver for Laravel Scout](https://laravel-news.com/explorer) <br>📖 [Algolia: Scout Extended](https://www.algolia.com/doc/framework-integration/laravel/getting-started/introduction-to-scout-extended/?client=php) <br>📄 [Full-Text Search with MeiliSearch and Laravel Scout](https://tighten.co/blog/full-text-search-with-meilisearch-and-scout/) <br>|
+| Laravel Scout |:book: [Laravel Scout](https://laravel.com/docs/scout) <br>|
+| Drivers: ElasticSearch, Algolia or MeiliSearch |:page_facing_up: [ElasticSearch Driver for Laravel Scout](https://laravel-news.com/explorer) <br>:book: [Algolia: Scout Extended](https://www.algolia.com/doc/framework-integration/laravel/getting-started/introduction-to-scout-extended/?client=php) <br>:page_facing_up: [Full-Text Search with MeiliSearch and Laravel Scout](https://tighten.co/blog/full-text-search-with-meilisearch-and-scout/) <br>|
 | **Laravel Packages** ||
-| Contributing to Packages, making Pull Requests |🎬 [How to Contribute to Laravel Docs (or any open-source repository)](https://www.youtube.com/watch?v=vEcT6JIFji0) <br>|
-| Create Laravel Packages |📖 [Package Development](https://laravel.com/docs/9.x/packages) <br>[:capital_abcd: Laravel Package Development](https://laravelpackage.com/) <br>|
+| Contributing to Packages, making Pull Requests |:clapper: [How to Contribute to Laravel Docs (or any open-source repository)](https://www.youtube.com/watch?v=vEcT6JIFji0) <br>|
+| Create Laravel Packages |:book: [Package Development](https://laravel.com/docs/packages) <br>:capital_abcd: [Laravel Package Development](https://laravelpackage.com/) <br>|
 
 
 ## Senior Level


### PR DESCRIPTION
Closes #22 caused by PR #21.
Removed the hardcoded Laravel version paths from the docs URLs, it'll redirect to the latest Laravel version's documentation.